### PR TITLE
Use `tail` as external pager instead of `cat`

### DIFF
--- a/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
+++ b/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
@@ -56,5 +56,5 @@ end);
 # The following are needed to make the help system
 # sort of play nice with the wrapper kernel
 SetUserPreference("browse", "SelectHelpMatches", false);
-SetUserPreference("Pager", "cat");
+SetUserPreference("Pager", "tail");
 SetUserPreference("PagerOptions", "");


### PR DESCRIPTION
As a comment in the GAP file lib/pager.gi says, for using `more`
or `less` or anything else set in `UserPreference("Pager")` we
assume that `UserPreference("Pager")` allows command line option
`+num` for starting display in line `num`.
