### PR TITLE
Online help

### DIFF
--- a/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
+++ b/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
@@ -53,6 +53,23 @@ function(dot)
     IO_unlink(fn);
 end);
 
+# This is another ugly hack to make the GAP Help System
+# play ball. Let us please fix this soon.
+HELP_VIEWER_INFO.jupyter_online :=
+    rec(
+         type := "url",
+         show := function(url)
+             local p,r;
+
+             p := url;
+
+             for r in GAPInfo.RootPaths do
+                 p := ReplacedString(url, r, "https://cloud.gap-system.org/");
+             od;
+             Print("<doclink dst=\"", p, "\">\n");
+         end
+        );
+
 # Make sure that we don't insert ugly line breaks into the
 # output stream
 SetPrintFormattingStatus("*stdout*", false);
@@ -62,3 +79,6 @@ SetPrintFormattingStatus("*stdout*", false);
 SetUserPreference("browse", "SelectHelpMatches", false);
 SetUserPreference("Pager", "tail");
 SetUserPreference("PagerOptions", "");
+# This is of course complete nonsense if you're running the jupyter notebook
+# on your local machine.
+SetHelpViewer("jupyter-online");

--- a/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
+++ b/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
@@ -66,7 +66,7 @@ HELP_VIEWER_INFO.jupyter_online :=
              for r in GAPInfo.RootPaths do
                  p := ReplacedString(url, r, "https://cloud.gap-system.org/");
              od;
-             Print("<a href=\"", p, "\">Help</a>\n");
+             Print("<a target=\"_blank\" href=\"", p, "\">Help</a>\n");
          end
         );
 

--- a/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
+++ b/wrapper-kernel/jupyter_gap_wrapper/gap/setup.g
@@ -66,13 +66,12 @@ HELP_VIEWER_INFO.jupyter_online :=
              for r in GAPInfo.RootPaths do
                  p := ReplacedString(url, r, "https://cloud.gap-system.org/");
              od;
-             Print("<doclink dst=\"", p, "\">\n");
+             Print("<a href=\"", p, "\">Help</a>\n");
          end
         );
 
 # Make sure that we don't insert ugly line breaks into the
 # output stream
-SetPrintFormattingStatus("*stdout*", false);
 
 # The following are needed to make the help system
 # sort of play nice with the wrapper kernel
@@ -81,4 +80,7 @@ SetUserPreference("Pager", "tail");
 SetUserPreference("PagerOptions", "");
 # This is of course complete nonsense if you're running the jupyter notebook
 # on your local machine.
-SetHelpViewer("jupyter-online");
+SetHelpViewer("jupyter_online");
+# The following is another hack because. Well I don't know why.
+SetPrintFormattingStatus("*stdout*", false);
+SET_PRINT_FORMATTING_STDOUT(false);

--- a/wrapper-kernel/jupyter_gap_wrapper/kernel.py
+++ b/wrapper-kernel/jupyter_gap_wrapper/kernel.py
@@ -48,6 +48,8 @@ class GAPKernel(Kernel):
     # Horrible, horrible hack
     def _xml_response(self, string):
         return not (re.match("<\?xml", string) is None)
+    def _doc_response(self, string):
+        return not (re.match("<doclink", string) is None)
 
     def _start_gap(self):
         # Signal handlers are inherited by forked processes, and we can't easily
@@ -99,6 +101,11 @@ class GAPKernel(Kernel):
                 self.send_response(self.iopub_socket, 'display_data', stream_content)
                 stream_content = {'name': 'stdout', 'text': 'Success'}
                 self.send_response(self.iopub_socket, 'stream', stream_content)
+            if self._doc_response(output):
+                stream_content = { 'source' : 'gap',
+		                   'data': { 'text/html': output },
+                                   'metadata': { }
+                self.send_response(self.iopub_socket, 'display_data', stream_content)
             else:
                 # Send standard output
                 stream_content = {'name': 'stdout', 'text': output}
@@ -154,3 +161,6 @@ class GAPKernel(Kernel):
         return {'matches': sorted(matches), 'cursor_start': start,
                 'cursor_end': cursor_pos, 'metadata': dict(),
                 'status': 'ok'}
+
+    def do_inspect(self, code, cursor_pos, detail_level=0):
+        return {'status': 'ok', 'found': 'true', 'data': 'Spass hassen spass', 'metadata':''}


### PR DESCRIPTION
A weak attempt at making any sort of an online help system work.

This goes and produces a link into the help hosted at https://cloud.gap-system.org/ and the user can click that. As an extension one should produce a list of links maybe. I don't like it but it works, and can be a starting point for further development.
